### PR TITLE
Add reward fee wait time and commit operator/treasury

### DIFF
--- a/contracts/near-x/src/constants.rs
+++ b/contracts/near-x/src/constants.rs
@@ -14,6 +14,8 @@ pub const TEN_NEAR: u128 = 10 * ONE_NEAR;
 pub const K_NEAR: u128 = 1_000 * ONE_NEAR;
 
 pub const NUM_EPOCHS_TO_UNLOCK: EpochHeight = 4;
+// Number of epochs to wait for reward fee to set
+pub const REWARD_FEE_SET_WAIT_TIME: EpochHeight = 4;
 
 /// Storage keys
 pub const ACCOUNTS_MAP: &str = "A";

--- a/contracts/near-x/src/contract.rs
+++ b/contracts/near-x/src/contract.rs
@@ -76,6 +76,63 @@ pub struct NearxPool {
     // This is to have 2 commit owner update
     pub temp_owner: Option<AccountId>,
 
+    pub temp_operator: Option<AccountId>,
+
+    pub temp_treasury: Option<AccountId>,
+
+    pub temp_reward_fee: Option<Fraction>,
+
+    pub last_reward_fee_set_epoch: EpochHeight,
+
+    // Operations control
+    pub operations_control: OperationControls,
+}
+
+#[near_bindgen]
+#[derive(BorshDeserialize, BorshSerialize, PanicOnDefault)]
+pub struct LegacyNearxPool {
+    pub owner_account_id: AccountId,
+
+    /// The total amount of tokens actually staked (the tokens are in the staking pools)
+    // nearx_price = (total_staked) / (total_stake_shares)
+    pub total_staked: u128,
+
+    /// how many "NearX" were minted.
+    pub total_stake_shares: u128, //total NearX minted
+
+    pub accumulated_staked_rewards: u128,
+
+    /// Amount of NEAR that is users requested to stake
+    pub user_amount_to_stake_in_epoch: Balance,
+    /// Amount of NEAR that is users requested to unstake
+    pub user_amount_to_unstake_in_epoch: Balance,
+
+    /// Amount of NEAR that actually needs to be staked in the epoch
+    pub reconciled_epoch_stake_amount: Balance,
+    /// Amount of NEAR that actually needs to be unstaked in the epoch
+    pub reconciled_epoch_unstake_amount: Balance,
+    /// Last epoch height stake/unstake amount were reconciled
+    pub last_reconcilation_epoch: EpochHeight,
+
+    // User account map
+    pub accounts: UnorderedMap<AccountId, Account>,
+
+    pub validator_info_map: UnorderedMap<AccountId, ValidatorInfo>,
+    pub total_validator_weight: u16,
+
+    /// min amount accepted as deposit or stake
+    pub min_deposit_amount: u128,
+
+    pub operator_account_id: AccountId,
+
+    pub treasury_account_id: AccountId,
+
+    pub rewards_fee: Fraction,
+
+    // Temp owner for owner update
+    // This is to have 2 commit owner update
+    pub temp_owner: Option<AccountId>,
+
     // Operations control
     pub operations_control: OperationControls,
 }

--- a/contracts/near-x/src/contract/upgrade.rs
+++ b/contracts/near-x/src/contract/upgrade.rs
@@ -11,8 +11,33 @@ impl NearxPool {
     #[init(ignore_state)]
     #[private]
     pub fn migrate() -> Self {
-        let contract: NearxPool = env::state_read().expect("ERR_NOT_INITIALIZED");
-        contract
+        let contract: LegacyNearxPool = env::state_read().expect("ERR_NOT_INITIALIZED");
+        let new_contract: NearxPool = NearxPool {
+            owner_account_id: contract.owner_account_id,
+            total_staked: contract.total_staked,
+            total_stake_shares: contract.total_stake_shares,
+            accumulated_staked_rewards: contract.accumulated_staked_rewards,
+            user_amount_to_stake_in_epoch: contract.user_amount_to_stake_in_epoch,
+            user_amount_to_unstake_in_epoch: contract.user_amount_to_unstake_in_epoch,
+            reconciled_epoch_stake_amount: contract.reconciled_epoch_stake_amount,
+            reconciled_epoch_unstake_amount: contract.reconciled_epoch_unstake_amount,
+            last_reconcilation_epoch: contract.last_reconcilation_epoch,
+            accounts: contract.accounts,
+            validator_info_map: contract.validator_info_map,
+            total_validator_weight: contract.total_validator_weight,
+            min_deposit_amount: contract.min_deposit_amount,
+            operator_account_id: contract.operator_account_id,
+            treasury_account_id: contract.treasury_account_id,
+            rewards_fee: contract.rewards_fee,
+            temp_owner: contract.temp_owner,
+            temp_operator: None,
+            temp_treasury: None,
+            temp_reward_fee: None,
+            last_reward_fee_set_epoch: 0,
+            operations_control: contract.operations_control,
+        };
+        env::state_write(&new_contract);
+        new_contract
     }
 }
 

--- a/contracts/near-x/src/contract/util.rs
+++ b/contracts/near-x/src/contract/util.rs
@@ -19,6 +19,20 @@ impl NearxPool {
         );
     }
 
+    pub fn assert_operator_calling(&self) {
+        require!(
+            env::predecessor_account_id() == self.operator_account_id,
+            ERROR_UNAUTHORIZED
+        );
+    }
+
+    pub fn assert_treasury_calling(&self) {
+        require!(
+            env::predecessor_account_id() == self.treasury_account_id,
+            ERROR_UNAUTHORIZED
+        );
+    }
+
     pub fn assert_min_deposit_amount(&self, amount: u128) {
         require!(amount >= self.min_deposit_amount, ERROR_MIN_DEPOSIT);
     }

--- a/contracts/near-x/src/errors.rs
+++ b/contracts/near-x/src/errors.rs
@@ -20,6 +20,9 @@ pub const ERROR_NON_POSITIVE_STAKE_SHARES: &str = "nearx to be minted must be gr
 
 /// Misc
 pub const ERROR_TEMP_OWNER_NOT_SET: &str = "Temp owner has not been set to any account";
+pub const ERROR_TEMP_OPERATOR_NOT_SET: &str = "Temp operator has not been set to any account";
+pub const ERROR_TEMP_TREASURY_NOT_SET: &str = "Temp treasury has not been set to any account";
+pub const ERROR_TEMP_REWARD_FEE_IS_NOT_SET: &str = "Temp reward fee is not set";
 pub const ERROR_UNAUTHORIZED: &str = "Unauthorized";
 pub const ERROR_MIN_DEPOSIT: &str = "Deposit should be greater than min deposit";
 pub const ERROR_MIN_BALANCE_FOR_CONTRACT_STORAGE: &str =
@@ -30,6 +33,8 @@ pub const ERROR_NOT_ENOUGH_GAS: &str = "Not enough pre-paid gas";
 pub const ERROR_REQUIRE_ONE_YOCTO_NEAR: &str = "Function requires at least one yocto near";
 pub const ERROR_EXPECT_RESULT_ON_CALLBACK: &str = "Callback expected result on callback";
 pub const ERROR_MIN_DEPOSIT_TOO_HIGH: &str = "Min deposit too high";
+pub const ERROR_TEMP_REWARD_FEE_SET_IN_WAIT_PERIOD: &str =
+    "Still in wait period for reward fee to be set";
 
 /// Validator related errors
 pub const ERROR_VALIDATOR_NOT_PAUSED: &str = "Validator not paused";

--- a/contracts/near-x/src/events.rs
+++ b/contracts/near-x/src/events.rs
@@ -159,12 +159,18 @@ pub enum Event {
         new_owner: AccountId,
         caller: AccountId,
     },
-    UpdateOperator {
+    SetOperator {
         old_operator: AccountId,
         new_operator: AccountId,
     },
-    UpdateTreasury {
+    CommitOperator {
+        new_operator: AccountId,
+    },
+    SetTreasury {
         old_treasury_account: AccountId,
+        new_treasury_account: AccountId,
+    },
+    CommitTreasury {
         new_treasury_account: AccountId,
     },
     UpdateOperationsControl {
@@ -173,6 +179,9 @@ pub enum Event {
     SetRewardFee {
         old_reward_fee: Fraction,
         new_reward_fee: Fraction,
+    },
+    CommitRewardFee {
+        commited_reward_fee: Fraction,
     },
     SetMinDeposit {
         old_min_deposit: U128,

--- a/contracts/near-x/src/fungible_token/nearx_token.rs
+++ b/contracts/near-x/src/fungible_token/nearx_token.rs
@@ -4,14 +4,13 @@ use crate::events::Event;
 use near_contract_standards::fungible_token::{
     core::FungibleTokenCore, metadata::FungibleTokenMetadata,
 };
-use near_sdk::env::log;
 use near_sdk::{
     assert_one_yocto,
     borsh::{self, BorshDeserialize, BorshSerialize},
     collections::{LazyOption, LookupMap},
     env, ext_contract,
     json_types::U128,
-    log, near_bindgen, AccountId, Balance, Gas, PanicOnDefault, PromiseOrValue, StorageUsage,
+    log, near_bindgen, AccountId, Balance, PanicOnDefault, PromiseOrValue, StorageUsage,
 };
 
 #[ext_contract(ext_ft_receiver)]

--- a/contracts/near-x/src/state.rs
+++ b/contracts/near-x/src/state.rs
@@ -59,6 +59,8 @@ pub struct NearxPoolStateResponse {
     pub reconciled_epoch_unstake_amount: U128,
     /// Last epoch height stake/unstake amount were reconciled
     pub last_reconcilation_epoch: U64,
+
+    pub temp_reward_fee: Option<Fraction>
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
@@ -199,6 +201,8 @@ pub struct RolesResponse {
     pub operator_account: AccountId,
     pub treasury_account: AccountId,
     pub temp_owner: Option<AccountId>,
+    pub temp_operator: Option<AccountId>,
+    pub temp_treasury: Option<AccountId>,
 }
 
 #[derive(Serialize, Deserialize)]


### PR DESCRIPTION
1. Set the reward fee in a temp store and commit the reward fee only after 4 epochs
2. allow commiting of operator and treasury which makes the setting of operator and treasury a 2 phase commit.